### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ than one argument.
 * **::** (Double Colon) Separator.
 * **!** (Exclamation) inline comment.
 * **;** (Semicolon) Separates Statement on single source line. Except when it is in a character context.
-* **&** (Ampersand) Line continuation charachter.
+* **&** (Ampersand) Line continuation character.
 
 ## Data types
 * integer 


### PR DESCRIPTION
@StanislavRadkov, I've corrected a typographical error in the documentation of the [Fortran-Cheat-Sheet](https://github.com/StanislavRadkov/Fortran-Cheat-Sheet) project. Specifically, I've changed charachter to character. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
